### PR TITLE
Add code-adviser.com to BLACK_LIST

### DIFF
--- a/gsi4d.user.js
+++ b/gsi4d.user.js
@@ -178,6 +178,7 @@
 				'stackoverrun.com',
 				'codeday.me',
 				'code-examples.net',
+				'code-adviser.com',
 				'kotaeta.com',
 				'tutorialmore.com',
 				'voidcc.com',


### PR DESCRIPTION
stackoverflow等の質問とその回答を機械的に翻訳しているだけのウェブサイト

http://www.code-adviser.com